### PR TITLE
Bug fix, documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,21 +64,21 @@ android_sdk:
     link:
       adb: [boolean]  If true, adb will be symlinked to '/usr/bin'
       sdkmanager: [boolean] If true, sdkmanager will be symlinked to '/usr/bin'
-    platform_tools:
-      channel: [stable, beta, canary] Indicates the channel to install platform tools from. Defaults to 'stable'
-    build_tools:
-      - version: [string] The version to install [required]
-        channel: [stable, beta, development, canary] Indicates the the channel to install from. Defaults to 'stable'
-    platforms:
-      - version: [integer] The version to install [required]
-        channel: [stable, beta, development, canary]  Indicates the the channel to install from. Defaults to 'stable'
-    ndk:
-      - version: [string] The version to install [required]
-        channel: [stable, beta, canary]  Indicates the the channel to install from. Defaults to 'stable'
-    cmake:
-      - version: [string] The version to install [required]
-        channel: [stable, beta, canary]  Indicates the the channel to install from. Defaults to 'stable'
-    plugdev_users: [string array] A list of users to add the 'plugdev' group to.
+  platform_tools:
+    channel: [stable, beta, canary] Indicates the channel to install platform tools from. Defaults to 'stable'
+  build_tools:
+    - version: [string] The version to install [required]
+      channel: [stable, beta, development, canary] Indicates the the channel to install from. Defaults to 'stable'
+  platforms:
+    - version: [integer] The version to install [required]
+      channel: [stable, beta, development, canary]  Indicates the the channel to install from. Defaults to 'stable'
+  ndk:
+    - version: [string] The version to install [required]
+      channel: [stable, beta, canary]  Indicates the the channel to install from. Defaults to 'stable'
+  cmake:
+    - version: [string] The version to install [required]
+      channel: [stable, beta, canary]  Indicates the the channel to install from. Defaults to 'stable'
+  plugdev_users: [string array] A list of users to add the 'plugdev' group to.
 ```
 
 #### Bootstrap

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -96,7 +96,7 @@
 
 - name: "Android | SDK | Install build tools"
   ansible.builtin.shell:
-    cmd: "{{ sdkmanager_path }} --install \"build-tools;{{ item.version }}\" --channel={{ four_channel_map[item.channel] | default('0') }} | grep -v = || true"
+    cmd: "{{ sdkmanager_path }} --install \"build-tools;{{ item.version }}\" --channel={{ four_channel_map[item.channel | default('stable')] | default('0') }} | grep -v = || true"
   environment:
     # The remote environment variables are not available to the task
     # and so the environment is supplied here.
@@ -118,7 +118,7 @@
 
 - name: "Android | SDK | Install platforms"
   ansible.builtin.shell:
-    cmd: "{{ sdkmanager_path }} --install \"platforms;android-{{ item.version }}\" --channel={{ four_channel_map[item.channel] | default('0') }} | grep -v = || true"
+    cmd: "{{ sdkmanager_path }} --install \"platforms;android-{{ item.version }}\" --channel={{ four_channel_map[item.channel | default('stable')] | default('0') }} | grep -v = || true"
   environment:
     # The remote environment variables are not available to the task
     # and so the environment is supplied here.
@@ -130,24 +130,24 @@
 
 - name: "Android | SDK | Install NDK"
   ansible.builtin.shell:
-    cmd: "{{ sdkmanager_path }} --install \"ndk;{{ item.version }}\" --channel={{ three_channel_map[item.channel] | default('0') }} | grep -v = || true"
+    cmd: "{{ sdkmanager_path }} --install \"ndk;{{ item.version }}\" --channel={{ three_channel_map[item.channel | default('stable')] | default('0') }} | grep -v = || true"
   environment:
     # The remote environment variables are not available to the task
     # and so the environment is supplied here.
     ANDROID_HOME: "{{ android_sdk_home }}"
-  loop: "{{ android_requested_sdk.ndk }}"
+  loop: "{{ android_sdk.ndk }}"
   when:
     - android_sdk.ndk is defined
     - android_sdk.ndk | length > 0
 
 - name: "Android | SDK | Install cmake"
   ansible.builtin.shell:
-    cmd: "{{ sdkmanager_path }} --install \"cmake;{{ item.version }}\" --channel={{ three_channel_map[item.channel] | default('0') }} | grep -v = || true"
+    cmd: "{{ sdkmanager_path }} --install \"cmake;{{ item.version }}\" --channel={{ three_channel_map[item.channel | default('stable')] | default('0') }} | grep -v = || true"
   environment:
     # The remote environment variables are not available to the task
     # and so the environment is supplied here.
     ANDROID_HOME: "{{ android_sdk_home }}"
-  loop: "{{ android_requested_sdk.cmake }}"
+  loop: "{{ android_sdk.cmake }}"
   when:
     - android_sdk.cmake is defined
     - android_sdk.cmake | length > 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: "Android | SDK | set 'android_sdk_home' variable"
   ansible.builtin.set_fact:
-    android_sdk_home: "{{  android_sdk.environment.variables.sdk_home.path | default(android_sdk_home) }}"
+    android_sdk_home: "{{ android_sdk.environment.variables.sdk_home.path | default(android_sdk_home) }}"
 
 - name: "Android | SDK | Configure sdk"
   ansible.builtin.import_tasks: configure.yml


### PR DESCRIPTION
Refactor: use 'android_sdk' variable (remove reference to non-existent 'android_requested_sdk'). Update documentation to match actual code. Set default values for 'channel' if not set (except for 'platform_tools', which requires a value in JSON)